### PR TITLE
Batch relationship objects can now point to other objects in the batch.

### DIFF
--- a/app/models/ddr/batch/batch_object.rb
+++ b/app/models/ddr/batch/batch_object.rb
@@ -31,8 +31,11 @@ module Ddr::Batch
         return pids
       end
 
+      def error_prefix
+        I18n.t('ddr.batch.errors.prefix', :identifier => identifier, :id => id)
+      end
+
       def validate
-        @error_prefix = I18n.t('ddr.batch.errors.prefix', :identifier => identifier, :id => id)
         errors = []
         errors += validate_model if model
         errors += validate_datastreams if batch_object_datastreams
@@ -66,7 +69,7 @@ module Ddr::Batch
         begin
           model.constantize
         rescue NameError
-          errs << "#{@error_prefix} Invalid model name: #{model}"
+          errs << "#{error_prefix} Invalid model name: #{model}"
         end
         return errs
       end
@@ -76,23 +79,23 @@ module Ddr::Batch
         batch_object_datastreams.each do |d|
           if model_datastream_keys.present?
             unless model_datastream_keys.include?(d.name.to_sym)
-              errs << "#{@error_prefix} Invalid datastream name for #{model}: #{d.name}"
+              errs << "#{error_prefix} Invalid datastream name for #{model}: #{d.name}"
             end
           end
           unless BatchObjectDatastream::PAYLOAD_TYPES.include?(d.payload_type)
-            errs << "#{@error_prefix} Invalid payload type for #{d.name} datastream: #{d.payload_type}"
+            errs << "#{error_prefix} Invalid payload type for #{d.name} datastream: #{d.payload_type}"
           end
           if d.payload_type.eql?(BatchObjectDatastream::PAYLOAD_TYPE_FILENAME)
             unless File.readable?(d.payload)
-              errs << "#{@error_prefix} Missing or unreadable file for #{d[:name]} datastream: #{d[:payload]}"
+              errs << "#{error_prefix} Missing or unreadable file for #{d[:name]} datastream: #{d[:payload]}"
             end
           end
           if d.checksum && !d.checksum_type
-            errs << "#{@error_prefix} Must specify checksum type if providing checksum for #{d.name} datastream"
+            errs << "#{error_prefix} Must specify checksum type if providing checksum for #{d.name} datastream"
           end
           if d.checksum_type
             unless Ddr::Datastreams::CHECKSUM_TYPES.include?(d.checksum_type)
-              errs << "#{@error_prefix} Invalid checksum type for #{d.name} datastream: #{d.checksum_type}"
+              errs << "#{error_prefix} Invalid checksum type for #{d.name} datastream: #{d.checksum_type}"
             end
           end
         end
@@ -102,44 +105,8 @@ module Ddr::Batch
       def validate_relationships
         errs = []
         batch_object_relationships.each do |r|
-          obj_model = nil
-          unless BatchObjectRelationship::OBJECT_TYPES.include?(r[:object_type])
-            errs << "#{@error_prefix} Invalid object_type for #{r[:name]} relationship: #{r[:object_type]}"
-          end
-          if r[:object_type].eql?(BatchObjectRelationship::OBJECT_TYPE_PID)
-            if batch.present? && batch.found_pids.keys.include?(r[:object])
-              obj_model = batch.found_pids[r[:object]]
-            else
-              begin
-                obj = ActiveFedora::Base.find(r[:object], :cast => true)
-                obj_model = obj.class.name
-                if batch.present?
-                  batch.add_found_pid(obj.pid, obj_model)
-                end
-              rescue ActiveFedora::ObjectNotFoundError
-                pid_in_batch = false
-                if batch.present?
-                  if batch.pre_assigned_pids.include?(r[:object])
-                    pid_in_batch = true
-                  end
-                end
-                unless pid_in_batch
-                  errs << "#{@error_prefix} #{r[:name]} relationship object does not exist: #{r[:object]}"
-                end
-              end
-            end
-            if obj_model
-              relationship_reflection = Ddr::Utils.relationship_object_reflection(model, r[:name])
-              if relationship_reflection
-                klass = Ddr::Utils.reflection_object_class(relationship_reflection)
-                if klass
-                  errs << "#{@error_prefix} #{r[:name]} relationship object #{r[:object]} exists but is not a(n) #{klass}" unless batch.found_pids[r[:object]].eql?(klass.name)
-                end
-              else
-                errs << "#{@error_prefix} #{model} does not define a(n) #{r[:name]} relationship"
-              end
-            end
-          end
+          r.valid?
+          errs += r.errors.messages.values.map { |msg| "#{error_prefix} msg" }
         end
         return errs
       end
@@ -147,8 +114,8 @@ module Ddr::Batch
       def verify_repository_object
         verifications = {}
         begin
-          repo_object = ActiveFedora::Base.find(pid, :cast => true)
-        rescue ActiveFedora::ObjectNotFound
+          repo_object = ActiveFedora::Base.find(pid)
+        rescue ActiveFedora::ObjectNotFoundError
           verifications["Object exists in repository"] = VERIFICATION_FAIL
         else
           verifications["Object exists in repository"] = VERIFICATION_PASS
@@ -221,11 +188,23 @@ module Ddr::Batch
       end
 
       def verify_relationship(repo_object, relationship)
+        # if PID, proceed as below
+        # if AR rec ID,
+        #   retrieve AR rec
+        #   if AR rec has PID, proceed as below using AR rec PID
+        #   if not, error (should not occur)
+        repo_object_id = case
+                           when relationship.object_rec_id?
+                             referent = batch.batch_objects.find(relationship.object)
+                             referent.pid
+                           when relationship.object_repo_id?
+                             relationship.object
+                         end
         relationship_reflection = Ddr::Utils.relationship_object_reflection(model, relationship.name)
         relationship_object_class = Ddr::Utils.reflection_object_class(relationship_reflection)
         relationship_object = repo_object.send(relationship.name)
         if !relationship_object.nil? &&
-            relationship_object.pid.eql?(relationship.object) &&
+            relationship_object.pid.eql?(repo_object_id) &&
             relationship_object.is_a?(relationship_object_class)
           VERIFICATION_PASS
         else
@@ -275,11 +254,19 @@ module Ddr::Batch
       end
 
       def add_relationship(repo_object, relationship)
-        relationship_object = case relationship[:object_type]
-        when BatchObjectRelationship::OBJECT_TYPE_PID
-          ActiveFedora::Base.find(relationship[:object], :cast => true)
+        repo_object_id = case
+                           when relationship.object_rec_id?
+                             referent = batch.batch_objects.find(relationship[:object])
+                             referent.pid
+                           when relationship.object_repo_id?
+                             relationship[:object]
+                         end
+        if repo_object_id.present?
+          relationship_object = ActiveFedora::Base.find(repo_object_id)
+          repo_object.send("#{relationship[:name]}=", relationship_object)
+        else
+          raise Ddr::Batch::Error, "Unable to determine repository ID for relationship #{relationship.id}"
         end
-        repo_object.send("#{relationship[:name]}=", relationship_object)
         return repo_object
       end
 

--- a/app/models/ddr/batch/batch_object_relationship.rb
+++ b/app/models/ddr/batch/batch_object_relationship.rb
@@ -1,7 +1,6 @@
 module Ddr::Batch
-
   class BatchObjectRelationship < ActiveRecord::Base
-#    attr_accessible :name, :object, :object_type, :operation, :batch_object
+
     belongs_to :batch_object, :inverse_of => :batch_object_relationships
 
     RELATIONSHIP_ADMIN_POLICY = "admin_policy"
@@ -15,12 +14,85 @@ module Ddr::Batch
       RELATIONSHIP_COMPONENT, RELATIONSHIP_ATTACHED_TO ]
 
     OPERATION_ADD = "ADD"
-    OPERATION_UPDATE = "UPDATE"
     OPERATION_DELETE = "DELETE"
+    OPERATION_UPDATE = "UPDATE"
 
-    OBJECT_TYPE_PID = "PID"
+    OPERATIONS = [ OPERATION_ADD, OPERATION_DELETE, OPERATION_UPDATE ]
 
-    OBJECT_TYPES = [ OBJECT_TYPE_PID ]
+    OBJECT_TYPE_REC_ID = "REC_ID"
+    OBJECT_TYPE_REPO_ID = "REPO_ID"
+
+    OBJECT_TYPES = [ OBJECT_TYPE_REC_ID, OBJECT_TYPE_REPO_ID ]
+
+    validates_presence_of :object, :batch_object
+
+    validates_inclusion_of :name, in: RELATIONSHIPS, message: 'Invalid relationship name'
+    validates_inclusion_of :operation, in: OPERATIONS, message: 'Invalid relationship operation'
+    validates_inclusion_of :object_type, in: OBJECT_TYPES, message: 'Invalid relationship object type'
+    validate :record_must_be_in_batch, if: :object_rec_id?
+    validate :repo_object_must_exist, if: :object_repo_id?
+    validate :relationship_name_must_be_valid_for_model
+
+    delegate :batch, to: :batch_object
+    delegate :batch_objects, to: :batch
+    delegate :found_pids, to: :batch
+    delegate :add_found_pid, to: :batch
+
+    def object_rec_id?
+      object_type == OBJECT_TYPE_REC_ID
+    end
+
+    def object_repo_id?
+      object_type == OBJECT_TYPE_REPO_ID
+    end
+
+    def record_must_be_in_batch
+      batch_objects.find(object).present?
+    rescue ActiveRecord::RecordNotFound
+        errors.add(:object, "#{object} not found in this batch")
+    end
+
+    def repo_object_must_exist
+      unless found_pids.keys.include?(object)
+        obj = ActiveFedora::Base.find(object)
+        add_found_pid(obj.id, obj.class.name)
+      end
+    rescue ActiveFedora::ObjectNotFoundError
+      errors.add(:object, "#{object} not found in repository")
+    end
+
+    def relationship_name_must_be_valid_for_model
+      unless Ddr::Utils.relationship_object_reflection(batch_object.model, name).present?
+        errors.add(:name, "#{batch_object.model} does not define a(n) #{name} relationship")
+      end
+    end
+
+    def object_model_must_be_correct_for_relationship
+      if relationship_reflection = Ddr::Utils.relationship_object_reflection(batch_object.model, name)
+        klass = Ddr::Utils.reflection_object_class(relationship_reflection)
+        if klass.present?
+          unless object_model == klass.name
+            errors.add(:object, "#{name} relationship object #{object} exists but is not a(n) #{klass}")
+          end
+        end
+      end
+    end
+
+    private
+
+    def object_model
+      case object_type
+        when OBJECT_TYPE_REC_ID
+          batch_objects.find(object).model
+        when OBJECT_TYPE_REPO_ID
+          if found_pids.keys.include?(object)
+            found_pids[object]
+          else
+            obj = ActiveFedora::Base.find(object)
+            add_found_pid(obj.id, obj.class.name)
+          end
+      end
+    end
+
   end
-
 end

--- a/app/models/ddr/batch/error.rb
+++ b/app/models/ddr/batch/error.rb
@@ -1,0 +1,6 @@
+module Ddr::Batch
+
+  # Base class for custom Ddr::Batch exceptions
+  class Error < StandardError; end
+
+end

--- a/app/models/ddr/batch/ingest_batch_object.rb
+++ b/app/models/ddr/batch/ingest_batch_object.rb
@@ -4,8 +4,7 @@ module Ddr::Batch
 
     def local_validations
       errors = []
-      errors << "#{@error_prefix} Model required for INGEST operation" unless model
-      errors += validate_pre_assigned_pid if pid
+      errors << "#{error_prefix} Model required for INGEST operation" unless model
       errors
     end
 
@@ -27,12 +26,6 @@ module Ddr::Batch
     end
 
     private
-
-    def validate_pre_assigned_pid
-      errs = []
-      errs << "#{@error_prefix} #{pid} already exists in repository" if ActiveFedora::Base.exists?(pid)
-      return errs
-    end
 
     def ingest(user, opts = {})
       repo_object = create_repository_object

--- a/app/models/ddr/batch/update_batch_object.rb
+++ b/app/models/ddr/batch/update_batch_object.rb
@@ -4,12 +4,12 @@ module Ddr::Batch
 
     def local_validations
       errs = []
-      errs << "#{@error_prefix} PID required for UPDATE operation" unless pid
+      errs << "#{error_prefix} PID required for UPDATE operation" unless pid
       if pid
         if ActiveFedora::Base.exists?(pid)
-          errs << "#{@error_prefix} #{batch.user.user_key} not permitted to edit #{pid}" unless batch.user.can?(:edit, ActiveFedora::Base.find(pid, :cast => true))
+          errs << "#{error_prefix} #{batch.user.user_key} not permitted to edit #{pid}" unless batch.user.can?(:edit, ActiveFedora::Base.find(pid, :cast => true))
         else
-          errs << "#{@error_prefix} PID #{pid} not found in repository" unless ActiveFedora::Base.exists?(pid)
+          errs << "#{error_prefix} PID #{pid} not found in repository" unless ActiveFedora::Base.exists?(pid)
         end
       end
       errs

--- a/spec/factories/batch_object_factories.rb
+++ b/spec/factories/batch_object_factories.rb
@@ -87,6 +87,7 @@ FactoryGirl.define do
     end
 
     factory :generic_ingest_batch_object do
+      has_batch
       has_model
       has_admin_policy
       has_parent
@@ -106,6 +107,7 @@ FactoryGirl.define do
     end
 
     factory :target_ingest_batch_object do
+      has_batch
       model "Target"
       is_target_for_collection
       with_add_content_datastream

--- a/spec/factories/batch_object_relationship_factories.rb
+++ b/spec/factories/batch_object_relationship_factories.rb
@@ -7,19 +7,19 @@ FactoryGirl.define do
       factory :batch_object_add_admin_policy do
         name "admin_policy"
         object { create(:collection).pid }
-        object_type Ddr::Batch::BatchObjectRelationship::OBJECT_TYPE_PID
+        object_type Ddr::Batch::BatchObjectRelationship::OBJECT_TYPE_REPO_ID
       end
 
       factory :batch_object_add_parent do
         name "parent"
         object { create(:test_parent).pid }
-        object_type Ddr::Batch::BatchObjectRelationship::OBJECT_TYPE_PID
+        object_type Ddr::Batch::BatchObjectRelationship::OBJECT_TYPE_REPO_ID
       end
 
       factory :batch_object_add_target_for_collection do
         name "collection"
         object { create(:collection).pid }
-        object_type Ddr::Batch::BatchObjectRelationship::OBJECT_TYPE_PID
+        object_type Ddr::Batch::BatchObjectRelationship::OBJECT_TYPE_REPO_ID
       end
 
     end

--- a/spec/models/batch_object_relationship_spec.rb
+++ b/spec/models/batch_object_relationship_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+module Ddr::Batch
+
+  RSpec.describe BatchObjectRelationship, type: :model do
+
+    subject { described_class.new }
+
+    let(:batch) { Batch.create }
+    let(:parent_batch_object) { BatchObject.new(id: 7) }
+    let(:batch_object) { BatchObject.new(model: 'TestChild') }
+    let(:repo_object) { double(id: 'test-123456') }
+
+    before do
+      parent_batch_object.batch = batch
+      parent_batch_object.save!
+      batch_object.batch = batch
+      batch_object.save!
+      subject.batch_object = batch_object
+    end
+
+    describe 'custom validations' do
+      describe 'record must be in batch' do
+        context 'invalid' do
+          before { subject.object = '4' }
+          it 'should produce an appropriate validation error' do
+            subject.record_must_be_in_batch
+            expect(subject.errors[:object]).to include("#{subject.object} not found in this batch")
+          end
+        end
+        context 'valid' do
+          before { subject.object = parent_batch_object.id.to_s }
+          it 'should not produce a validation error' do
+            subject.record_must_be_in_batch
+            expect(subject.errors[:object]).to be_empty
+          end
+        end
+      end
+      describe 'repo object must exist' do
+        before { subject.object = repo_object.id }
+        context 'invalid' do
+          it 'should produce an appropriate validation error' do
+            subject.repo_object_must_exist
+            expect(subject.errors[:object]).to include("#{subject.object} not found in repository")
+          end
+        end
+        context 'valid' do
+          before { allow(ActiveFedora::Base).to receive(:find).with(repo_object.id) { repo_object } }
+          it 'should not produce a validation error' do
+            subject.repo_object_must_exist
+            expect(subject.errors[:object]).to be_empty
+          end
+        end
+      end
+      describe 'relationship name must be valid' do
+        context 'invalid' do
+          before { subject.name = BatchObjectRelationship::RELATIONSHIP_ATTACHED_TO }
+          it 'should produce an appropriate validation error' do
+            subject.relationship_name_must_be_valid_for_model
+            expect(subject.errors[:name]).to include("#{batch_object.model} does not define a(n) #{subject.name} relationship")
+          end
+        end
+        context 'valid' do
+          before { subject.name = BatchObjectRelationship::RELATIONSHIP_PARENT }
+          it 'should not produce a validation error' do
+            subject.relationship_name_must_be_valid_for_model
+            expect(subject.errors[:name]).to be_empty
+          end
+        end
+      end
+      describe 'model of object must be correct for relationship' do
+        let(:correct_model) { 'TestParent' }
+        before do
+          subject.name = BatchObjectRelationship::RELATIONSHIP_PARENT
+        end
+        context 'invalid' do
+          context 'object is record ID' do
+            before do
+              subject.object_type = BatchObjectRelationship::OBJECT_TYPE_REC_ID
+              subject.object = parent_batch_object.id.to_s
+              parent_batch_object.model = 'NotParent'
+              parent_batch_object.save!
+            end
+            it 'should produce an appropriate validation error' do
+              subject.object_model_must_be_correct_for_relationship
+              expect(subject.errors[:object]).to include("#{subject.name} relationship object #{subject.object} exists but is not a(n) #{correct_model}")
+            end
+          end
+          context 'object is repo ID' do
+            before do
+              subject.object_type = BatchObjectRelationship::OBJECT_TYPE_REPO_ID
+              subject.object = repo_object.id
+              allow(ActiveFedora::Base).to receive(:find).with(repo_object.id) { repo_object }
+              allow(repo_object).to receive(:class) { Attachment }
+            end
+            it 'should produce an appropriate validation error' do
+              subject.object_model_must_be_correct_for_relationship
+              expect(subject.errors[:object]).to include("#{subject.name} relationship object #{subject.object} exists but is not a(n) #{correct_model}")
+            end
+          end
+        end
+        context 'valid' do
+          context 'object is record ID' do
+            before do
+              subject.object_type = BatchObjectRelationship::OBJECT_TYPE_REC_ID
+              subject.object = parent_batch_object.id.to_s
+              parent_batch_object.model = 'TestParent'
+              parent_batch_object.save!
+            end
+            it 'should not produce a validation error' do
+              subject.object_model_must_be_correct_for_relationship
+              expect(subject.errors[:object]).to be_empty
+            end
+          end
+          context 'object is repo ID' do
+            before do
+              subject.object_type = BatchObjectRelationship::OBJECT_TYPE_REPO_ID
+              subject.object = repo_object.id
+              allow(ActiveFedora::Base).to receive(:find).with(repo_object.id) { repo_object }
+              allow(repo_object).to receive(:class) { TestParent }
+            end
+            it 'should not produce a validation error' do
+              subject.object_model_must_be_correct_for_relationship
+              expect(subject.errors[:object]).to be_empty
+            end
+          end
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -39,19 +39,17 @@ module Ddr::Batch
     context "validate" do
       let(:parent) { FactoryGirl.create(:test_parent) }
       let(:pid_cache) { { parent.pid => parent.class.name} }
-      before do
+      it "should cache the results of looking up relationship objects" do
+        expect(batch).to receive(:add_found_pid).once.with(parent.pid, "TestParent").and_call_original
         batch.batch_objects.each do |obj|
           obj.batch_object_relationships <<
               BatchObjectRelationship.new(
                   :name => BatchObjectRelationship::RELATIONSHIP_PARENT,
                   :object => parent.pid,
-                  :object_type => BatchObjectRelationship::OBJECT_TYPE_PID,
+                  :object_type => BatchObjectRelationship::OBJECT_TYPE_REPO_ID,
                   :operation => BatchObjectRelationship::OPERATION_ADD
-                  )
+              )
         end
-      end
-      it "should cache the results of looking up relationship objects" do
-        expect(batch).to receive(:add_found_pid).once.with(parent.pid, "TestParent").and_call_original
         batch.validate
         expect(batch.found_pids).to eq(pid_cache)
       end

--- a/spec/models/ingest_batch_object_spec.rb
+++ b/spec/models/ingest_batch_object_spec.rb
@@ -32,36 +32,23 @@ module Ddr::Batch
 
     context "validate" do
 
+      context "relationships" do
+        let(:object) { FactoryGirl.create(:generic_ingest_batch_object) }
+        it "should valdiate the relationships" do
+          object.batch_object_relationships.each do |r|
+            expect(r).to receive(:valid?)
+          end
+          object.validate
+        end
+      end
+
       context "valid object" do
         context "generic object" do
-          let(:object) { FactoryGirl.create(:generic_ingest_batch_object_with_bytes, :has_batch) }
+          let(:object) { FactoryGirl.create(:generic_ingest_batch_object_with_bytes) }
           it_behaves_like "a valid ingest object"
         end
         context "target object" do
-          let(:object) { FactoryGirl.create(:target_ingest_batch_object, :has_batch) }
-          it_behaves_like "a valid ingest object"
-        end
-        context "object related to an uncreated object with pre-assigned PID" do
-          let(:object) { FactoryGirl.create(:generic_ingest_batch_object_with_bytes) }
-          let(:parent) { FactoryGirl.create(:generic_ingest_batch_object_with_bytes) }
-          let(:parent_pid) { 'test:4321' }
-          let(:batch) { FactoryGirl.create(:batch) }
-          let(:relationship) do
-            BatchObjectRelationship.create(
-              :name => BatchObjectRelationship::RELATIONSHIP_PARENT,
-              :object => parent_pid,
-              :object_type => BatchObjectRelationship::OBJECT_TYPE_PID,
-              :operation => BatchObjectRelationship::OPERATION_ADD
-              )
-          end
-          before do
-            object.batch = batch
-            object.batch_object_relationships << relationship
-            object.save
-            parent.batch = batch
-            parent.pid = parent_pid
-            parent.save
-          end
+          let(:object) { FactoryGirl.create(:target_ingest_batch_object) }
           it_behaves_like "a valid ingest object"
         end
       end
@@ -78,36 +65,6 @@ module Ddr::Batch
           let(:error_message) { "#{error_prefix} Invalid model name: #{object.model}" }
           before { object.model = "BadModel" }
           it_behaves_like "an invalid ingest object"
-        end
-        context "pre-assigned pid already exists" do
-          let(:object) { FactoryGirl.create(:ingest_batch_object, :has_model) }
-          let(:existing_object) { FactoryGirl.create(:test_model) }
-          let(:error_message) { "#{error_prefix} #{existing_object.pid} already exists in repository" }
-          before { object.pid = existing_object.pid }
-          it_behaves_like "an invalid ingest object"
-        end
-        context "invalid admin policy" do
-          let(:object) { FactoryGirl.create(:ingest_batch_object, :has_batch, :has_model) }
-          context "admin policy pid object does not exist" do
-            let(:admin_policy_pid) { "bogus-AdminPolicy" }
-            let(:error_message) { "#{error_prefix} admin_policy relationship object does not exist: #{admin_policy_pid}" }
-            before do
-              relationship = FactoryGirl.create(:batch_object_add_relationship, :name => "admin_policy", :object => admin_policy_pid, :object_type => BatchObjectRelationship::OBJECT_TYPE_PID)
-              object.batch_object_relationships << relationship
-              object.save
-            end
-            it_behaves_like "an invalid ingest object"
-          end
-          context "admin policy pid object exists but is not admin policy" do
-            let(:error_message) { "#{error_prefix} admin_policy relationship object #{@not_admin_policy.pid} exists but is not a(n) Collection" }
-            before do
-              @not_admin_policy = FactoryGirl.create(:test_model)
-              relationship = FactoryGirl.create(:batch_object_add_relationship, :name => "admin_policy", :object => @not_admin_policy.pid, :object_type => BatchObjectRelationship::OBJECT_TYPE_PID)
-              object.batch_object_relationships << relationship
-              object.save
-            end
-            it_behaves_like "an invalid ingest object"
-          end
         end
         context "invalid datastreams" do
           let(:object) { FactoryGirl.create(:ingest_batch_object, :has_model, :with_add_extracted_text_datastream_bytes, :with_add_content_datastream) }
@@ -158,54 +115,6 @@ module Ddr::Batch
             it_behaves_like "an invalid ingest object"
           end
         end
-        context "invalid parent" do
-          let(:object) { FactoryGirl.create(:ingest_batch_object, :has_batch, :has_model) }
-          context "parent pid object does not exist" do
-            let(:parent_pid) { "bogus-TestParent" }
-            let(:error_message) { "#{error_prefix} parent relationship object does not exist: #{parent_pid}" }
-            before do
-              relationship = FactoryGirl.create(:batch_object_add_relationship, :name => "parent", :object => parent_pid, :object_type => BatchObjectRelationship::OBJECT_TYPE_PID)
-              object.batch_object_relationships << relationship
-              object.save
-            end
-            it_behaves_like "an invalid ingest object"
-          end
-          context "parent pid object exists but is not correct parent object type" do
-            let(:error_message) { "#{error_prefix} parent relationship object #{@not_parent.pid} exists but is not a(n) TestParent" }
-            before do
-              @not_parent = FactoryGirl.create(:test_model)
-              relationship = FactoryGirl.create(:batch_object_add_relationship, :name => "parent", :object => @not_parent.pid, :object_type => BatchObjectRelationship::OBJECT_TYPE_PID)
-              object.batch_object_relationships << relationship
-              object.save
-            end
-            it_behaves_like "an invalid ingest object"
-          end
-        end
-        context "invalid target_for" do
-          let(:object) { FactoryGirl.create(:ingest_batch_object, :has_batch) }
-          context "target_for pid object does not exist" do
-            let(:collection_pid) { "bogus-Collection" }
-            let(:error_message) { "#{error_prefix} collection relationship object does not exist: #{collection_pid}" }
-            before do
-              object.model = "Target"
-              relationship = FactoryGirl.create(:batch_object_add_relationship, :name => "collection", :object => collection_pid, :object_type => BatchObjectRelationship::OBJECT_TYPE_PID)
-              object.batch_object_relationships << relationship
-              object.save
-            end
-            it_behaves_like "an invalid ingest object"
-          end
-          context "target_for pid object exists but is not collection" do
-            let(:error_message) { "#{error_prefix} collection relationship object #{@not_collection.pid} exists but is not a(n) Collection" }
-            before do
-              @not_collection = FactoryGirl.create(:test_model)
-              object.model = "Target"
-              relationship = FactoryGirl.create(:batch_object_add_relationship, :name => "collection", :object => @not_collection.pid, :object_type => BatchObjectRelationship::OBJECT_TYPE_PID)
-              object.batch_object_relationships << relationship
-              object.save
-            end
-            it_behaves_like "an invalid ingest object"
-          end
-        end
       end
     end
 
@@ -213,7 +122,7 @@ module Ddr::Batch
 
       let(:user) { FactoryGirl.create(:user) }
       context "successful ingest" do
-        context "object without a pre-assigned PID" do
+        context "not previously ingested object" do
           let(:assigned_pid) { nil }
           context "payload type bytes" do
             let(:object) { FactoryGirl.create(:generic_ingest_batch_object_with_bytes) }
@@ -227,15 +136,34 @@ module Ddr::Batch
             let(:object) { FactoryGirl.create(:generic_ingest_batch_object_with_attributes) }
             it_behaves_like "a successful ingest"
           end
-        end
-        context "object with a pre-assigned PID" do
-          let(:object) { FactoryGirl.create(:generic_ingest_batch_object_with_bytes) }
-          let(:assigned_pid) { SecureRandom.uuid }
-          before do
-            object.pid = assigned_pid
-            object.save
+          context "relationship with record ID object" do
+            let(:batch) { Ddr::Batch::Batch.create }
+            let(:parent_repo_object) { TestParent.create }
+            let(:parent_object) do
+              Ddr::Batch::IngestBatchObject.create(
+                  batch: batch,
+                  model: 'TestParent',
+                  pid: parent_repo_object.id)
+            end
+            let(:object) do
+              Ddr::Batch::IngestBatchObject.create(
+                  batch: batch,
+                  model: 'TestChild')
+            end
+            let(:relationship) do
+              BatchObjectRelationship.new(
+                operation: BatchObjectRelationship::OPERATION_ADD,
+                name: BatchObjectRelationship::RELATIONSHIP_PARENT,
+                object_type: BatchObjectRelationship::OBJECT_TYPE_REC_ID,
+                object:parent_object.id
+              )
+            end
+            before do
+              object.batch_object_relationships << relationship
+              object.save
+            end
+            it_behaves_like "a successful ingest"
           end
-          it_behaves_like "a successful ingest"
         end
         context "previously ingested object (e.g., during restart)" do
           let(:object) { FactoryGirl.create(:generic_ingest_batch_object_with_bytes) }


### PR DESCRIPTION
They can also point directly to repository objects but the addition of this option eliminates the
need to pre-mint repository ID's to use as the objects of relationships.
