### PR TITLE
Fix BatchObject#add_relationship bug; closes #22.

### DIFF
--- a/app/models/ddr/batch/batch_object.rb
+++ b/app/models/ddr/batch/batch_object.rb
@@ -120,7 +120,6 @@ module Ddr::Batch
         else
           verifications["Object exists in repository"] = VERIFICATION_PASS
           verifications["Object is correct model"] = verify_model(repo_object) if model
-          # verifications["Object has correct label"] = verify_label(repo_object) if label
           unless batch_object_attributes.empty?
             batch_object_attributes.each do |a|
               if a.operation == BatchObjectAttribute::OPERATION_ADD
@@ -157,10 +156,6 @@ module Ddr::Batch
         end
       end
 
-      # def verify_label(repo_object)
-      #   repo_object.label.eql?(label) ? VERIFICATION_PASS : VERIFICATION_FAIL
-      # end
-      #
       def verify_attribute(repo_object, attribute)
         verified = case attribute.datastream
           when 'descMetadata'

--- a/app/models/ddr/batch/ingest_batch_object.rb
+++ b/app/models/ddr/batch/ingest_batch_object.rb
@@ -44,7 +44,6 @@ module Ddr::Batch
           event.detail = ingest_outcome_detail.join("\n")
           event.save!
         end
-        update_attributes(:pid => repo_object.pid)
         verifications = verify_repository_object
         verification_outcome_detail = []
         verified = true
@@ -76,8 +75,8 @@ module Ddr::Batch
       repo_object = nil
       begin
         repo_object = model.constantize.new(:id => repo_pid)
-        # repo_object.label = label if label
         repo_object.save(validate: false)
+        update_attributes(:pid => repo_object.pid)
         batch_object_attributes.each { |a| repo_object = add_attribute(repo_object, a) }
         batch_object_datastreams.each { |d| repo_object = populate_datastream(repo_object, d) }
         batch_object_relationships.each { |r| repo_object = add_relationship(repo_object, r) }
@@ -94,6 +93,7 @@ module Ddr::Batch
           else
             repo_clean = true
           end
+          update_attributes(pid: nil)
         else
           repo_clean = true
         end


### PR DESCRIPTION
Moves point at which newly created repository object ID is saved in the
BatchObject record.  Adds relevant spec test.
