### PR TITLE
Uprade ddr-models to v3.0.0.beta.17.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,4 @@ gem "devise"
 # To use debugger
 # gem 'debugger'
 
-gem 'ddr-models', '3.0.0.beta.13'
+gem 'ddr-models', '3.0.0.beta.17'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,8 @@ require 'deprecation'
 # users commonly want.
 #
 # Silence deprecation warnings
-warn "Default deprecation behavior set to :silence!"
-Deprecation.default_deprecation_behavior = :silence
+# warn "Default deprecation behavior set to :silence!"
+# Deprecation.default_deprecation_behavior = :silence
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION
Also unsilence deprecations since existing ones have been addressed.
