### PR TITLE
Remove dependency on keeping track of successes and failures in batch…

### DIFF
--- a/app/mailers/ddr/batch/batch_processor_run_mailer.rb
+++ b/app/mailers/ddr/batch/batch_processor_run_mailer.rb
@@ -9,6 +9,9 @@ module Ddr::Batch
       @title = "Batch Processor Run #{@batch.status} #{@batch.outcome}"
       @host = `uname -n`.strip
       @subject = "[#{@host}] #{@title}"
+      @size = @batch.batch_objects.size
+      @handled = @batch.handled_count
+      @success = @batch.success_count
       from = "#{`echo $USER`.strip}@#{@host}"
       attachments["details.txt"] = File.read(@batch.logfile.path)
       mail(from: from, to: @batch.user.email, subject: @subject)

--- a/app/models/ddr/batch/batch.rb
+++ b/app/models/ddr/batch/batch.rb
@@ -26,6 +26,10 @@ module Ddr::Batch
       batch_objects.where(handled: true).count
     end
 
+    def success_count
+      batch_objects.where(verified: true).count
+    end
+
     def time_to_complete
       unless start.nil?
         if handled_count > 0

--- a/app/services/ddr/batch/monitor_batch_finished.rb
+++ b/app/services/ddr/batch/monitor_batch_finished.rb
@@ -60,7 +60,7 @@ module Ddr::Batch
       end
 
       def update_batch(batch)
-        outcome = batch.success.eql?(batch.batch_objects.size) ? Batch::OUTCOME_SUCCESS : Batch::OUTCOME_FAILURE
+        outcome = batch.success_count.eql?(batch.batch_objects.size) ? Batch::OUTCOME_SUCCESS : Batch::OUTCOME_FAILURE
         logfile = File.new(Ddr::Batch::Log.file_path(batch.id))
         batch.update!(stop: DateTime.now,
                       status: Batch::STATUS_FINISHED,

--- a/app/services/ddr/batch/monitor_batch_object_handled.rb
+++ b/app/services/ddr/batch/monitor_batch_object_handled.rb
@@ -13,7 +13,6 @@ module Ddr::Batch
 
       def batch_object_handled(batch_object, batch)
         log_batch_object_messages(batch_object, batch.id)
-        update_batch(batch_object, batch)
         unless batch.unhandled_objects?
           ActiveSupport::Notifications.instrument('finished.batch.batch.ddr', batch_id: batch.id)
         end
@@ -25,10 +24,6 @@ module Ddr::Batch
           logger.add(message.level) { "Batch Object #{batch_object.id}: #{message.message}" }
         end
         logger.close
-      end
-
-      def update_batch(batch_object, batch)
-        batch_object.verified? ? batch.update!(success: batch.success + 1) : batch.update!(failure: batch.failure + 1)
       end
     end
 

--- a/app/views/ddr/batch/batch_processor_run_mailer/send_notification.html.erb
+++ b/app/views/ddr/batch/batch_processor_run_mailer/send_notification.html.erb
@@ -22,10 +22,10 @@ td { text-align: right; }
 	  Outcome: <%= @batch.outcome %>
 	</p>
 	<p>
-	  Objects in batch: <%= @batch.batch_objects.size %><br />
-	  Successfully processed: <%= @batch.success %><br />
-	  Processing failures: <%= @batch.failure %><br />
-	  Unprocessed: <%= @batch.batch_objects.size - @batch.success - @batch.failure %>
+	  Objects in batch: <%= @size %><br />
+	  Successfully processed: <%= @success %><br />
+	  Processing failures: <%= @handled - @success %><br />
+	  Unprocessed: <%= @size - @handled %>
 	</p>
 	<p>
 	  See attachment for details of batch run.

--- a/app/views/ddr/batch/batch_processor_run_mailer/send_notification.text.erb
+++ b/app/views/ddr/batch/batch_processor_run_mailer/send_notification.text.erb
@@ -12,9 +12,9 @@ Stopped at: <%= @batch.stop %>
 Status: <%= @batch.status %>
 Outcome: <%= @batch.outcome %>
 
-Objects in batch: <%= @batch.batch_objects.size %>
-Successfully processed: <%= @batch.success %>
-Processing failures: <%= @batch.failure %>
-Unprocessed: <%= @batch.batch_objects.size - @batch.success - @batch.failure %>
+Objects in batch: <%= @size %>
+Successfully processed: <%= @success %>
+Processing failures: <%= @handled - @success %>
+Unprocessed: <%= @size - @handled %>
 
 See attachment for details of batch run.

--- a/db/migrate/20161222192611_remove_columns_from_batch.rb
+++ b/db/migrate/20161222192611_remove_columns_from_batch.rb
@@ -1,0 +1,13 @@
+class RemoveColumnsFromBatch < ActiveRecord::Migration
+  def up
+    remove_column :batches, :failure
+    remove_column :batches, :success
+  end
+
+  def down
+    change_table :batches do |t|
+      t.integer  "failure",               default: 0
+      t.integer  "success",               default: 0
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161116142512) do
+ActiveRecord::Schema.define(version: 20161222192611) do
 
   create_table "batch_object_attributes", force: true do |t|
     t.integer  "batch_object_id"
@@ -91,8 +91,6 @@ ActiveRecord::Schema.define(version: 20161116142512) do
     t.datetime "start"
     t.datetime "stop"
     t.string   "outcome"
-    t.integer  "failure",               default: 0
-    t.integer  "success",               default: 0
     t.string   "version"
     t.string   "logfile_file_name"
     t.string   "logfile_content_type"


### PR DESCRIPTION
…; addresses #DDR-375.

When running multiple queue workers for batch processing, race conditions (I presume) make
keeping count of successes and failures in the batch object problematic.