### PR TITLE
Ensure components included in batch processing are part of batch bein…

### DIFF
--- a/spec/services/process_batch_spec.rb
+++ b/spec/services/process_batch_spec.rb
@@ -13,38 +13,51 @@ module Ddr::Batch
     end
 
     describe "ingest batch" do
-      context "collection creating" do
+      describe "type of batch" do
+        context "collection creating" do
+          let(:batch) { FactoryGirl.create(:collection_creating_ingest_batch) }
+          it "should call the appropriate methods" do
+            expect(pb).to receive(:ingest_collection_object).with(batch.batch_objects[0])
+            expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[1].id, batch.batch_objects[2].id ], batch.user.id)
+            expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[3].id, batch.batch_objects[4].id, batch.batch_objects[5].id ], batch.user.id)
+            expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[6].id ], batch.user.id)
+            expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[7].id ], batch.user.id)
+            pb.execute
+          end
+          describe "collection creation failure" do
+            before do
+              allow(ActiveSupport::Notifications).to receive(:instrument).with("started.batch.batch.ddr", batch_id: batch.id)
+              pbo = ProcessBatchObject.new(batch_object_id: batch.batch_objects[0].id, operator: User.find(batch.user.id))
+              allow(ProcessBatchObject).to receive(:new).and_call_original
+              allow(ProcessBatchObject).to receive(:new).with(batch_object_id: batch.batch_objects[0].id, operator: User.find(batch.user.id)) { pbo }
+              allow(pbo).to receive(:execute) { false }
+            end
+            it "should issue a 'batch finished' notification and raise an exception" do
+              expect(ActiveSupport::Notifications).to receive(:instrument).with("finished.batch.batch.ddr", batch_id: batch.id)
+              expect { pb.execute }.to raise_error(Ddr::Batch::BatchObjectProcessingError)
+            end
+          end
+        end
+        context "item adding" do
+          let(:batch) { FactoryGirl.create(:item_adding_ingest_batch) }
+          it "should call the appropriate methods" do
+            expect(pb).to_not receive(:ingest_collection_object)
+            expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[0].id, batch.batch_objects[1].id ], batch.user.id)
+            expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[2].id, batch.batch_objects[3].id, batch.batch_objects[4].id ], batch.user.id)
+            expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[5].id ], batch.user.id)
+            expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[6].id ], batch.user.id)
+            pb.execute
+          end
+        end
+      end
+      describe "previous batch with conflicting repository ID's" do
+        let!(:prev_batch) { FactoryGirl.create(:collection_creating_ingest_batch) }
         let(:batch) { FactoryGirl.create(:collection_creating_ingest_batch) }
-        it "should call the appropriate methods" do
-          expect(pb).to receive(:ingest_collection_object).with(batch.batch_objects[0])
+        it "should include the correct batch objects in the processing jobs" do
           expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[1].id, batch.batch_objects[2].id ], batch.user.id)
           expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[3].id, batch.batch_objects[4].id, batch.batch_objects[5].id ], batch.user.id)
           expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[6].id ], batch.user.id)
           expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[7].id ], batch.user.id)
-          pb.execute
-        end
-        describe "collection creation failure" do
-          before do
-            allow(ActiveSupport::Notifications).to receive(:instrument).with("started.batch.batch.ddr", batch_id: batch.id)
-            pbo = ProcessBatchObject.new(batch_object_id: batch.batch_objects[0].id, operator: User.find(batch.user.id))
-            allow(ProcessBatchObject).to receive(:new).and_call_original
-            allow(ProcessBatchObject).to receive(:new).with(batch_object_id: batch.batch_objects[0].id, operator: User.find(batch.user.id)) { pbo }
-            allow(pbo).to receive(:execute) { false }
-          end
-          it "should issue a 'batch finished' notification and raise an exception" do
-            expect(ActiveSupport::Notifications).to receive(:instrument).with("finished.batch.batch.ddr", batch_id: batch.id)
-            expect { pb.execute }.to raise_error(Ddr::Batch::BatchObjectProcessingError)
-          end
-        end
-      end
-      context "item adding" do
-        let(:batch) { FactoryGirl.create(:item_adding_ingest_batch) }
-        it "should call the appropriate methods" do
-          expect(pb).to_not receive(:ingest_collection_object)
-          expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[0].id, batch.batch_objects[1].id ], batch.user.id)
-          expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[2].id, batch.batch_objects[3].id, batch.batch_objects[4].id ], batch.user.id)
-          expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[5].id ], batch.user.id)
-          expect(Resque).to receive(:enqueue).with(BatchObjectsProcessorJob, [ batch.batch_objects[6].id ], batch.user.id)
           pb.execute
         end
       end


### PR DESCRIPTION
…g processed; fixes DDR-525.

Fixes an edge case bug where batch objects table contains entries in another batch with the
same repository ID as entry in current batch.