### PR TITLE
Skip structue updates during batch ingest; DDR-1149.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem "devise"
 gem "rails", "4.2.7"
+gem "ddr-models", git: "https://github.com/duke-libraries/ddr-models", ref: "a7765bbd60c389440dfc0e50d0f13cbbb1d81df3"

--- a/app/models/ddr/batch/ingest_batch_object.rb
+++ b/app/models/ddr/batch/ingest_batch_object.rb
@@ -97,11 +97,11 @@ module Ddr::Batch
         repo_object = model.constantize.new(:pid => repo_pid)
         repo_object.label = label if label
         batch_object_attributes.each { |a| repo_object = add_attribute(repo_object, a) }
-        repo_object.save(validate: false)
+        repo_object.save(validate: false, skip_structure_updates: true)
         batch_object_datastreams.each { |d| repo_object = populate_datastream(repo_object, d) }
         batch_object_relationships.each { |r| repo_object = add_relationship(repo_object, r) }
         batch_object_roles.each { |r| repo_object = add_role(repo_object, r) }
-        repo_object.save!
+        repo_object.save!(skip_structure_updates: true)
       rescue Exception => e1
         logger.fatal("Error in creating repository object #{repo_object.pid} for #{identifier} : #{e1}")
         if repo_object && !repo_object.new_record?

--- a/ddr-batch.gemspec
+++ b/ddr-batch.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara", "~> 2.0"
   s.add_development_dependency "jettywrapper", "~> 1.8"
   s.add_development_dependency "database_cleaner"
+  s.add_development_dependency "byebug"
 end


### PR DESCRIPTION
Structure updates based on a batch ingest are handled after the batch completes by a
notification subscriber in DulHydra (SetDefaultStructuresAfterSuccessfulBatchIngest).