### PR TITLE
Pass batch user to first repository object save to trigger setting of…

### DIFF
--- a/app/models/ddr/batch/ingest_batch_object.rb
+++ b/app/models/ddr/batch/ingest_batch_object.rb
@@ -47,7 +47,7 @@ module Ddr::Batch
     end
 
     def ingest(user, opts = {})
-      repo_object = create_repository_object
+      repo_object = create_repository_object(user)
       if !repo_object.nil? && !repo_object.new_record?
         ingest_outcome_detail = []
         ingest_outcome_detail << "Ingested #{model} #{identifier} into #{repo_object.pid}"
@@ -90,14 +90,14 @@ module Ddr::Batch
       repo_object
     end
 
-    def create_repository_object
+    def create_repository_object(user)
       repo_pid = pid if pid.present?
       repo_object = nil
       begin
         repo_object = model.constantize.new(:pid => repo_pid)
         repo_object.label = label if label
         batch_object_attributes.each { |a| repo_object = add_attribute(repo_object, a) }
-        repo_object.save(validate: false, skip_structure_updates: true)
+        repo_object.save(validate: false, skip_structure_updates: true, user: user)
         batch_object_datastreams.each { |d| repo_object = populate_datastream(repo_object, d) }
         batch_object_relationships.each { |r| repo_object = add_relationship(repo_object, r) }
         batch_object_roles.each { |r| repo_object = add_role(repo_object, r) }

--- a/spec/models/ingest_batch_object_spec.rb
+++ b/spec/models/ingest_batch_object_spec.rb
@@ -21,6 +21,7 @@ module Ddr::Batch
     it "should result in a verified repository object" do
       expect(object.verified).to be_truthy
       expect(object.pid).to eq(assigned_pid) if assigned_pid.present?
+      expect(repo_object.ingested_by).to eq(user.user_key)
       if desc_metadata_provided
         expect(repo_object.title).to eq(["Test Object Title"])
       end
@@ -290,7 +291,10 @@ module Ddr::Batch
             repo_object = object.model.constantize.new(:pid => assigned_pid, title: ["Test Object Title"])
             repo_object.save(validate: false)
           end
-          it_behaves_like "a successful ingest"
+          it "does not (re-)ingest the object" do
+            expect(object).not_to receive(:ingest)
+            object.process(user)
+          end
         end
       end
 


### PR DESCRIPTION
… 'ingested_by' attribute; partially addresses DDR-1255.

Also replaces an unrelated spec test with a better test.