### PR TITLE
Skip batch objects that have already been successfully processed; DDR…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gemspec
 gem "devise"
 gem "rails", "4.2.7"
 gem "ddr-models", git: "https://github.com/duke-libraries/ddr-models", ref: "79c379a9a1a4c9300c4d1060789e8d77d14596ad"
+gem "byebug"

--- a/app/services/ddr/batch/process_batch_objects.rb
+++ b/app/services/ddr/batch/process_batch_objects.rb
@@ -12,21 +12,25 @@ module Ddr::Batch
       # Assume successful processing of all batch objects until proven otherwise.
       success = true
       batch_object_ids.each do |batch_object_id|
-        # Once any batch object included in this job fails to process successfully, do not attempt to process
-        # any remaining batch objects included in this job.  Instead, mark them as "handled" so the batch knows
-        # it's not waiting on them to be handled before it can consider itself "finished".
-        # The use case prompting this behavior is a job containing an Item ingest batch object plus one or more
-        # associated Component ingest batch objects.  If the Item batch object fails to process correctly, we don't
-        # want to attempt to process the Component batch objects.
-        # In the preceding use case, we could skip the remaining batch objects only if the failed batch object is an
-        # Item but there might be future cases in which we don't want to process the remaining batch objects in the
-        # job regardless of which batch object fails.  The failure of any batch object to process should be rare
-        # enough that it doesn't seem harmful to cover this potential broader use case in the current code.
-        if success
-          success = ProcessBatchObject.new(batch_object_id: batch_object_id, operator: operator).execute
-        else
-          batch_object = Ddr::Batch::BatchObject.find(batch_object_id)
-          batch_object.update!(handled: true)
+        batch_object = Ddr::Batch::BatchObject.find(batch_object_id)
+        # Skip batch objects that have already been successfully processed.  This is useful when this service is
+        # called within the context of a BatchObjectsProcessorJob, that job fails, and the failed job is retried.
+        unless batch_object.verified?
+          # Once any batch object included in this job fails to process successfully, do not attempt to process
+          # any remaining batch objects included in this job.  Instead, mark them as "handled" so the batch knows
+          # it's not waiting on them to be handled before it can consider itself "finished".
+          # The use case prompting this behavior is a job containing an Item ingest batch object plus one or more
+          # associated Component ingest batch objects.  If the Item batch object fails to process correctly, we don't
+          # want to attempt to process the Component batch objects.
+          # In the preceding use case, we could skip the remaining batch objects only if the failed batch object is an
+          # Item but there might be future cases in which we don't want to process the remaining batch objects in the
+          # job regardless of which batch object fails.  The failure of any batch object to process should be rare
+          # enough that it doesn't seem harmful to cover this potential broader use case in the current code.
+          if success
+            success = ProcessBatchObject.new(batch_object_id: batch_object.id, operator: operator).execute
+          else
+            batch_object.update!(handled: true)
+          end
         end
       end
     end

--- a/spec/services/process_batch_objects_spec.rb
+++ b/spec/services/process_batch_objects_spec.rb
@@ -27,5 +27,16 @@ module Ddr::Batch
       end
     end
 
+    describe "some objects processed" do
+      before do
+        batch.batch_objects.first.update_attributes(verified: true)
+        allow(ProcessBatchObject).to receive(:new).with(batch_object_id: batch.batch_objects[1].id, operator: batch.user).and_call_original
+        allow_any_instance_of(ProcessBatchObject).to receive(:execute) { true }
+      end
+      it "should not process the already processed objects" do
+        expect(ProcessBatchObject).to_not receive(:new).with(batch_object_id: batch.batch_objects[0].id, operator: batch.user)
+        pbos.execute
+      end
+    end
   end
 end


### PR DESCRIPTION
…-1416.

Also add 'byebug' to Gemfile for debugging convenience.